### PR TITLE
Bump to `v3.2` of `action-pulsar-dependency`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ jobs:
     steps:
       - name: Checkout the Latest Package Code
         uses: actions/checkout@v3
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install Package Dependencies
+        run: npm install
       - name: Setup Pulsar Editor
         uses: pulsar-edit/action-pulsar-dependency@v3.2
       - name: Run the Headless Pulsar Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,8 @@ jobs:
       - name: Checkout the Latest Package Code
         uses: actions/checkout@v3
       - name: Setup Pulsar Editor
-        uses: pulsar-edit/action-pulsar-dependency@v2.1
-        with:
-          package-to-test: "notifications"
+        uses: pulsar-edit/action-pulsar-dependency@v3.2
       - name: Run the Headless Pulsar Tests
-        uses: GabrielBB/xvfb-action@v1
+        uses: coactions/setup-xvfb@v1.0.1
         with:
-          run: yarn start --test spec
-          working-directory: ./pulsar
+          run: pulsar --test spec


### PR DESCRIPTION
This PR bumps out tests for this repo to our newest and fully functional version.

So this way we could be confident in the changes being proposed.

This is coming before an attempt will be made t sort out open PR's and issues here before bundling with the core.